### PR TITLE
Fix-summarize

### DIFF
--- a/R/fnct_create.R
+++ b/R/fnct_create.R
@@ -185,7 +185,11 @@ create_mean_data <- function(data, input_source) {
     #  # can use  init = base_df
     grouped_summary_df <- Reduce(
       function(x, y) {
-        dplyr::full_join(x, y, by = summary_grouping_vars)
+        dplyr::full_join(
+          x,
+          y,
+          by = c("organism_type", "data_type", summary_grouping_vars)
+        )
       },
       summary_list
       # init = base_df

--- a/R/fnct_create.R
+++ b/R/fnct_create.R
@@ -158,7 +158,11 @@ create_mean_data <- function(data, input_source) {
       }
 
       grouped_summary_df <- df_filtered |>
-        dplyr::group_by(dplyr::across(dplyr::all_of(summary_grouping_vars))) |>
+        dplyr::group_by(dplyr::across(dplyr::all_of(c(
+          "organism_type",
+          "data_type",
+          summary_grouping_vars
+        )))) |>
         dplyr::summarise(
           !!paste0(var_label, " (mean)") := mean(
             .data[[var_to_summarise]],
@@ -188,7 +192,7 @@ create_mean_data <- function(data, input_source) {
     grouped_summary_df <- grouped_summary_df |>
       dplyr::left_join(
         base_df,
-        by = summary_grouping_vars,
+        by = c("organism_type", "data_type", summary_grouping_vars),
         na_matches = "na"
       ) |>
       dplyr::relocate(

--- a/R/fnct_create.R
+++ b/R/fnct_create.R
@@ -135,6 +135,8 @@ create_mean_data <- function(data, input_source) {
       return(grouped_summary_df)
     }
 
+    # ----- df here maybe needs to be base_df? ------
+    # maybe not?
     summary_list <- lapply(y_vals, function(v) {
       mapped_var <- fix_var_generic(df = df, var_raw = v)
 

--- a/R/fnct_vectors.R
+++ b/R/fnct_vectors.R
@@ -315,7 +315,7 @@ themes <- function() {
     "Stable Isotopes",
     "Amino Acids",
     "Fatty Acids",
-    "Contaminates",
+    "Contaminants",
     "Thiamine"
   )
   return(themes)


### PR DESCRIPTION
Summarize was doing weird things where it was displayign the same values across data types this was because the 

`group_by()` on line 163 of fnct_create - `create_mean_data()` aws not using `"organism_type",
          "data_type"` nor was the `Reduce()` or `left_join()`. This has been fixed 